### PR TITLE
accept chef license after install to allow kitchen to run

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ trigger:
 
 variables:
   release.version:
+  CHEF_LICENSE: accept
 
 pool:
   vmImage: 'Ubuntu-16.04'
@@ -22,10 +23,6 @@ steps:
 
 - task: chef-software.vsts-chef-tasks.vsts-chef-task-install-chefdk.vsts-chef-task-install-chefdk@1
   displayName: 'Install ChefDK'
-
-- script: 'chef exec chef --chef-license accept'
-  displayName: Accept Chef License
-  continueOnError: true
 
 - script: 'cookstyle .'
   displayName: cookstyle

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
 - task: chef-software.vsts-chef-tasks.vsts-chef-task-install-chefdk.vsts-chef-task-install-chefdk@1
   displayName: 'Install ChefDK'
 
-- script: 'chef exec --chef-license accept'
+- script: 'chef exec chef --chef-license accept'
   displayName: Accept Chef License
   continueOnError: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,10 @@ steps:
 - task: chef-software.vsts-chef-tasks.vsts-chef-task-install-chefdk.vsts-chef-task-install-chefdk@1
   displayName: 'Install ChefDK'
 
+- script: 'chef exec --chef-license accept'
+  displayName: Accept Chef License
+  continueOnError: true
+
 - script: 'cookstyle .'
   displayName: cookstyle
   continueOnError: true


### PR DESCRIPTION
Add another step to DevOps pipeline to accept the Chef License as long as the Chef Tasks for DevOps do not handle that automatically.